### PR TITLE
modify size unit

### DIFF
--- a/RESOURCE/external-link.svg
+++ b/RESOURCE/external-link.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1rem" height="1rem" viewBox="0 0 100 100"><path fill="none" stroke="steelblue" stroke-width="10" d="m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 100 100"><path fill="none" stroke="steelblue" stroke-width="10" d="m43,35H5v60h60V57M45,5v10l10,10-30,30 20,20 30-30 10,10h10V5z"/></svg>


### PR DESCRIPTION
FireFox似乎不支持SVG当中的「rem」，于是改为「em」。